### PR TITLE
add pyproject.toml to enable using pip to install the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ The SWIRL code requires Python 3 and makes use of the following Python libraries
 ----
 
 ## How to install
-Download or clone this github repository into your machine. To import the module, run the following lines
+Download or clone this github repository into your machine. 
+
+The easiest way to install the code is to use pip:
 ```
->>> import sys
->>> sys.path.append(r'\path\to\the\folder')
->>> import swirl
+python3 -m pip install . 
 ```
 
-Alternatively, you can add the folder where you saved the code to your PYTHONPATH and simply import the swirl module:
+If you're a developer and want to install the code in editable mode, you can run:
 ```
->>> import swirl
+python3 -m pip install -e .
 ```
 
 ## How to run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "swirl"
+description = "The SWirl Identification by Rotation centers Localization (SWIRL) is an automated vortex identification algorithm written in python and based on the _Estimated Vortex Center_ (EVC) method [Canivete Cuissa & Steiner, 2022]. Given a two-dimensional velocity field defined on a Cartesian grid and the grid cell size in physical units, the SWIRL code returns a list with the identified vortical structures and their main properties."
+version = "1.0.0"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+keywords = ["vortex", "fluid dynamics", "physics", "simulation"]
+authors = [
+    { name = "José Roberto Canivete Cuissa", email = "jose.canivete@irsol.usi.ch" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Operating System :: OS Independent",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Fluid Dynamics",
+  "Topic :: Scientific/Engineering :: Physics",
+
+]
+dependencies = ["numpy>=1.21.6", 
+		"scipy>=1.4.1",
+		"matplotlib>=3.3.2",
+		"h5py>=2.10.0"]
+[tool.setuptools.packages.find]
+where = ["swirl"]
+
+[project.urls]
+Documentation = "https://github.com/jcanivete/swirl/blob/main/README.md"
+Issues = "https://github.com/jcanivete/swirl/issues"
+Source = "https://github.com/jcanivete/swirl"
+
+
+[tool.pdm]
+distribution = true
+
+[tool.setuptools]
+include-package-data = true
+
+

--- a/upload_to_pip.sh
+++ b/upload_to_pip.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+rm ./dist/*
+python3 -m build
+python3 -m twine upload --repository pypi dist/* --verbose


### PR DESCRIPTION
Hello, 


pyproject.toml is added, so that we can use pip too install swirl:
pip install . 

This will also make it easy to upload the package to pypi, which would be nice  so there is no need to download the source code before installation. But there is already a different code called swirl on pypi ( https://pypi.org/project/swirl/). 

Thanks for creating this nice package. I am a physicist doing lattice structure and spin simulations. There are a group of people here (Phythema group at the University of Liege in Belgium) interested in using swirl to detect the vortices of electric polarization and spins.  We'll be happy to extend the swirl code and contribute. 

Best regards, 
Xu He